### PR TITLE
Update BasicQueue.java

### DIFF
--- a/src/shuo/laoma/file/c61/BasicQueue.java
+++ b/src/shuo/laoma/file/c61/BasicQueue.java
@@ -26,7 +26,7 @@ public class BasicQueue {
 	private MappedByteBuffer metaBuf;
 
 	public BasicQueue(String path, String queueName) throws IOException {
-		if (path.endsWith(File.separator)) {
+		if (!path.endsWith(File.separator)) {
 			path += File.separator;
 		}
 		RandomAccessFile dataFile = null;


### PR DESCRIPTION
构造器里，对文件目录名缺分隔符的自动加上的处理有问题